### PR TITLE
Fix routing issues for users to see /play

### DIFF
--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -49,36 +49,36 @@ const App: React.FC = () => {
   const [selectedCategory, setSelectedCategoryApp] = useState<String>('')
   const [gameData, setGameData] = useState({})
   const [guesses, setGuesses] = useState<Guesses>(
-  { 
-    Antartica: {
-      correct: 0, 
-      total: 0
-    }, 
-    "North America": {
-      correct: 0, 
-      total: 0
-    }, 
-    "South America": {
-      correct: 0, 
-      total: 0
-    }, 
-    Asia: {
-      correct: 0, 
-      total: 0
-    }, 
-    Oceania: {
-      correct: 0, 
-      total: 0
-    }, 
-    Europe: {
-      correct: 0, 
-      total: 0
-    }, 
-    Africa: {
-      correct: 0, 
-      total: 0
-    } 
-  })
+    {
+      Antartica: {
+        correct: 0,
+        total: 0
+      },
+      "North America": {
+        correct: 0,
+        total: 0
+      },
+      "South America": {
+        correct: 0,
+        total: 0
+      },
+      Asia: {
+        correct: 0,
+        total: 0
+      },
+      Oceania: {
+        correct: 0,
+        total: 0
+      },
+      Europe: {
+        correct: 0,
+        total: 0
+      },
+      Africa: {
+        correct: 0,
+        total: 0
+      }
+    })
 
   // -------- Game Data Fetch ----------
 
@@ -127,6 +127,10 @@ const App: React.FC = () => {
     }
   }
 
+  const updateScore = (updatedGuesses) => {
+    setGuesses(updatedGuesses)
+  }
+
   const filterSelections = (categoryData: string) => {
     let gameData = []
     for (let country of selectedContinent.countries) {
@@ -138,6 +142,7 @@ const App: React.FC = () => {
 
   return (
     <main className="app-container">
+      {/* {console.log("gameData", gameData)} */}
       <NavLink to='/' className='home-link'>
         <h1 className="title" data-cy="title">Trivia Game</h1>
       </NavLink>
@@ -150,7 +155,7 @@ const App: React.FC = () => {
               alt="rotating earth gif"
               data-cy="earth-gif" />
             <div className="home-buttons">
-              <NavLink to='/play' className='select-link'>
+              <NavLink to='/selections' className='select-link'>
                 <button className="select-game" data-cy="select-game-btn">Select Game</button>
               </NavLink>
               <NavLink to='/scoreboard' className='scoreboard-link'>
@@ -159,19 +164,19 @@ const App: React.FC = () => {
             </div>
           </div>}
         />
-        {data.length && <Route
-          path="/play"
+        <Route
+          path="/selections"
           element={<Continents continents={data}
             assignSelections={assignSelections}
             filterSelections={filterSelections} />}
-        />}
-        <Route
-          path="/h"
-          element={<Trivia countries={data}/>}
         />
         <Route
           path="/scoreboard"
-          element={<Scoreboard keepScore={keepScore} guesses={guesses} />} 
+          element={<Scoreboard keepScore={keepScore} guesses={guesses} />}
+        />
+        <Route
+          path="/play"
+          element={<Trivia gameData={gameData} guesses={guesses} updateScore={updateScore} />}
         />
       </Routes>
     </main>

--- a/src/Components/Continents/Continents.tsx
+++ b/src/Components/Continents/Continents.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, ButtonHTMLAttributes, useRef } from 'react'
 import { SyntheticEvent } from 'react'
 import { CountriesData } from '../../countries.model'
 import './Continents.css'
+import { Route, Routes, NavLink, Link } from 'react-router-dom'
 
 interface CountriesProps {
   continents: CountriesData[]
@@ -37,7 +38,6 @@ const Continents: React.FC<CountriesProps> = (props): JSX.Element => {
     setSelectedContinent(continent)
   }
   const assignCategory = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault()
     props.assignSelections(event.currentTarget.name)
     setSelectedCategory(event.currentTarget.name)
     props.filterSelections(event.currentTarget.name)
@@ -48,9 +48,11 @@ const Continents: React.FC<CountriesProps> = (props): JSX.Element => {
       {!contienentKeys.length && <div>{continentsButtons}</div>}
       {contienentKeys.length > 0 && selectedCategory === '' ?
         <div>
+          <NavLink to="/play">
           <button className="option-button" key="emoji" name="emoji" onClick={(event) => assignCategory(event)}>Flags</button>
           <button className="option-button" key="capital" name="capital" onClick={(event) => assignCategory(event)}>Capitals</button>
           <button className="option-button" key="languages" name="languages" onClick={(event) => assignCategory(event)}>Languages</button>
+          </NavLink>
         </div>
         : null}
     </div>

--- a/src/Components/Trivia/Trivia.tsx
+++ b/src/Components/Trivia/Trivia.tsx
@@ -3,101 +3,45 @@ import { CountriesData } from '../../countries.model'
 import { NavLink } from 'react-router-dom'
 import './Trivia.css'
 
-//- MOSTLY DONE: need a randomizer to randomly select a country's flag... with the filter limiting it to the proper continent.
-//- DONE: need a randomizer to randomly select 3 other country names
-//---- DONE: firstly, ensuring that 1 of the four is the correct answer
-//---- DONE: secondly, ensuring that the other 3 do not contain the correct answer
-//---- WIP: thirdly, ensuring that a country whose flag is in the current quiz does NOT show up on the pool of    ------"other answers"... to make ------ sure repeats don't happen
-//---- NOT NECESSARY: fourthly, ensuring that the 3 WRONG countries in one question do not re-appear too often, if at all, ------in future questions
-//---- fifthly, ensuring that the correct answer is not always 'ANSWER C'
-
-//Let's keep it bite-sized and start with a 10-question quiz!
-
-
-
-// WIP: On initial page load, the first question should pop up. The user should get one try. Correct/incorrect should be stored globally to keep a scoreboard. After an option is clicked, a "next" button should appear.
-
-
 type CountriesProps = {
- countries: CountriesData[]
-}
- 
-const Trivia: React.FC <CountriesProps> = (countries) => {
- const [selectedCountry, setSelectedCountry] = useState({})
- const tempArray = [
-  {
-    country: 'Algeria',
-    emoji: '🇩🇿',
-  },
-  {
-    country: 'Tunisia',
-    emoji: '🇹🇳',
-  },
-  {
-    country: 'Libya',
-    emoji: '🇱🇾',
-  },
-  {
-    country: 'Morocco',
-    emoji: '🇲🇦',
-  },
-  {
-    country: 'Egypt',
-    emoji: '🇪🇬',
-  },
-  {
-    country: 'South Africa',
-    emoji: '🇿🇦',
-  }
- ]
-
-const shuffle = (array: any) => {
-  var length = array.length, current, remaining;
-
-  while (length) {
-
-    remaining = Math.floor(Math.random() * length--);
-
-    current = array[length];
-    array[length] = array[remaining];
-    array[remaining] = current;
-  }
-
-  return array;
+  countries: CountriesData[]
 }
 
-const randomizedArray = shuffle(tempArray)
+const Trivia: React.FC<CountriesProps> = (props) => {
+  
 
- const currentQuestion = (
+
+
+  const currentQuestion = (
     <div className="card">
       <h2 className="which-question">Which country uses this flag?</h2>
-      <h1 className="emoji">{randomizedArray[0].emoji}</h1>  
+      <h1 className="emoji">{randomizedArray[0].emoji}</h1>
     </div>
- )
+  )
 
-const currentChoices = [
-  <button className="mc-button" id="mc-a">{randomizedArray[0].country}</button>,
-  <button className="mc-button" id="mc-b">{randomizedArray[1].country}</button>,
-  <button className="mc-button" id="mc-c">{randomizedArray[2].country}</button>,
-  <button className="mc-button" id="mc-d">{randomizedArray[3].country}</button>
-]
+  const currentChoices = [
+    <button className="mc-button" id="mc-a">{randomizedArray[0].country}</button>,
+    <button className="mc-button" id="mc-b">{randomizedArray[1].country}</button>,
+    <button className="mc-button" id="mc-c">{randomizedArray[2].country}</button>,
+    <button className="mc-button" id="mc-d">{randomizedArray[3].country}</button>
+  ]
 
-const randomOrder = shuffle([0, 1, 2, 3])
+  const randomOrder = shuffle([0, 1, 2, 3])
 
- //makebuttonappear()
- //clickbutton(), which fires reset() and newquestion()
- 
- return (
-   <div className="questions-content">
-     <div className="question">{currentQuestion}</div>
-     <div className='mc-buttons'>
-      {currentChoices[randomOrder[0]]}
-      {currentChoices[randomOrder[1]]}
-      {currentChoices[randomOrder[2]]}
-      {currentChoices[randomOrder[3]]}
+  //makebuttonappear()
+  //clickbutton(), which fires reset() and newquestion()
+
+  return (
+    <div className="questions-content">
+      <div className="question">{currentQuestion}</div>
+      <div className='mc-buttons'>
+        {currentChoices[randomOrder[0]]}
+        {currentChoices[randomOrder[1]]}
+        {currentChoices[randomOrder[2]]}
+        {currentChoices[randomOrder[3]]}
       </div>
-   </div>
- )
+    </div>
+  )
 }
- 
+
 export default Trivia


### PR DESCRIPTION
#### What does this PR do?
- Renames routes and removes unneeded conditional rendering in `App.tsx`
- Fixes routing so when a user clicks on a category they are routed to `/play`
- Adds a function `updateScore()` to update score that can be passed into` Trivia.tsx `

#### How to test 
- Click through user path and arrive at `/play `after clicking a category  
